### PR TITLE
feat: save user last seen

### DIFF
--- a/src/components/LastSeen.js
+++ b/src/components/LastSeen.js
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import Router from "next/router";
+
+import { useAuthState } from "../context/auth";
+import { gql, hasuraUserClient } from "../lib/hasura-user-client";
+
+const UpdateUserLastSeen = gql`
+  mutation UpdateUserLastSeen($id: uuid!, $now: timestamptz!) {
+    update_users(where: { id: { _eq: $id } }, _set: { last_seen: $now }) {
+      returning {
+        last_seen
+      }
+    }
+  }
+`;
+
+export default function LastSeen({ children }) {
+  const { isAuthenticated, user, save_last_seen } = useAuthState();
+
+  useEffect(() => {
+    if (!isAuthenticated || !save_last_seen) return;
+
+    Router.events.on("routeChangeComplete", updateLastSeen);
+
+    return () => Router.events.off("routeChangeComplete", updateLastSeen);
+  }, [isAuthenticated, save_last_seen]);
+
+  const updateLastSeen = async () => {
+    const hasura = hasuraUserClient();
+
+    await hasura.request(UpdateUserLastSeen, {
+      id: user.id,
+      now: new Date().toISOString(),
+    });
+  };
+
+  return children;
+}

--- a/src/context/auth.js
+++ b/src/context/auth.js
@@ -14,6 +14,7 @@ const initialState = {
   isAuthenticated: false,
   user: null,
   token: null,
+  save_last_seen: false,
 };
 
 function reducer(state, { payload, type }) {
@@ -47,7 +48,7 @@ function AuthProvider({ children }) {
     saveAuthState(state);
   }, [state, saveAuthState]);
 
-  const login = async ({ email, password }) => {
+  const login = async ({ email, password, save_last_seen }) => {
     const res = await fetch("/api/login", {
       method: "POST",
       body: JSON.stringify({ email, password }),
@@ -62,10 +63,10 @@ function AuthProvider({ children }) {
 
     const { token, ...user } = json;
 
-    dispatch({ type: LOGIN_SUCCESS, payload: { token, user } });
+    dispatch({ type: LOGIN_SUCCESS, payload: { token, user, save_last_seen } });
   };
 
-  const register = async ({ name, email, password }) => {
+  const register = async ({ name, email, password, save_last_seen }) => {
     const res = await fetch("/api/register", {
       method: "POST",
       body: JSON.stringify({ name, email, password }),
@@ -80,7 +81,7 @@ function AuthProvider({ children }) {
 
     const { token, ...user } = json;
 
-    dispatch({ type: LOGIN_SUCCESS, payload: { token, user } });
+    dispatch({ type: LOGIN_SUCCESS, payload: { token, user, save_last_seen } });
   };
 
   const updateUser = (payload) => dispatch({ type: UPDATE_USER, payload });

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -3,11 +3,14 @@ import "../styles/app.css";
 import "react-mde/lib/styles/css/react-mde-all.css";
 
 import { AuthProvider } from "../context/auth";
+import LastSeen from "../components/LastSeen";
 
 export default function MyApp({ Component, pageProps }) {
   return (
     <AuthProvider>
-      <Component {...pageProps} />
+      <LastSeen>
+        <Component {...pageProps} />
+      </LastSeen>
     </AuthProvider>
   );
 }

--- a/src/pages/api/login.js
+++ b/src/pages/api/login.js
@@ -10,6 +10,7 @@ const GetUserByEmail = gql`
       name
       email
       password
+      last_seen
     }
   }
 `;

--- a/src/pages/api/register.js
+++ b/src/pages/api/register.js
@@ -19,6 +19,7 @@ const InsertUser = gql`
       id
       name
       email
+      last_seen
     }
   }
 `;

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -68,6 +68,18 @@ export default function RegisterPage() {
           {errors.password && <span>{errors.password.message}</span>}
         </div>
         <div>
+          <label htmlFor="save_last_seen">
+            <input
+              type="checkbox"
+              id="save_last_seen"
+              name="save_last_seen"
+              ref={register}
+              defaultChecked={true}
+            />
+            Show as online to other users
+          </label>
+        </div>
+        <div>
           <button type="submit" disabled={isSubmitting}>
             Login
           </button>

--- a/src/pages/register.js
+++ b/src/pages/register.js
@@ -86,6 +86,18 @@ export default function RegisterPage() {
           {errors.password && <span>{errors.password.message}</span>}
         </div>
         <div>
+          <label htmlFor="save_last_seen">
+            <input
+              type="checkbox"
+              id="save_last_seen"
+              name="save_last_seen"
+              ref={register}
+              defaultChecked={true}
+            />
+            Show as online to other users
+          </label>
+        </div>
+        <div>
           <button type="submit" disabled={isSubmitting}>
             Create account
           </button>


### PR DESCRIPTION
Closes #46

This stores the user last seen on route change complete hook from Next.

If the user chooses not to show their online status when logging in, or
registering then nothing is saved to their profile. Privacy!
